### PR TITLE
chore: remove generic git from detector

### DIFF
--- a/pkg/git/detector/detector.go
+++ b/pkg/git/detector/detector.go
@@ -10,7 +10,6 @@ import (
 	"github.com/redhat-developer/devconsole-git/pkg/log"
 	"sync"
 
-	"github.com/redhat-developer/devconsole-git/pkg/git/repository/generic"
 	"github.com/redhat-developer/devconsole-git/pkg/git/repository/github"
 )
 
@@ -42,10 +41,7 @@ func detectBuildEnvs(log *log.GitSourceLogger,
 		return nil, err
 	}
 	if service == nil {
-		service, err = generic.NewRepositoryService(gitSource, secretProvider)
-		if err != nil {
-			return nil, err
-		}
+		return &v1alpha1.BuildEnvStats{}, nil
 	}
 	return detectBuildEnvsUsingService(service)
 }

--- a/pkg/git/detector/detector_whitebox_test.go
+++ b/pkg/git/detector/detector_whitebox_test.go
@@ -44,18 +44,8 @@ func TestDetectBuildEnvsShouldUseGenericGitIfNotOtherMatches(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, buildEnvStats)
 
-	buildTools := buildEnvStats.DetectedBuildTypes
-	require.Len(t, buildTools, 2)
-
-	assertContainsBuildTool(t, buildTools, build.Maven, "pom.xml")
-	assertContainsBuildTool(t, buildTools, build.NodeJS, "package.json")
-
-	langs := buildEnvStats.SortedLanguages
-	assert.Len(t, langs, 4)
-	assert.Equal(t, "Go", langs[0])
-	assert.Equal(t, "Java", langs[1])
-	assert.Equal(t, "JSON", langs[2])
-	assert.Equal(t, "XML", langs[3])
+	assert.Empty(t, buildEnvStats.DetectedBuildTypes)
+	assert.Empty(t, buildEnvStats.SortedLanguages)
 }
 
 func TestFailingCreator(t *testing.T) {
@@ -81,9 +71,9 @@ func TestFailingGenericGitCreation(t *testing.T) {
 	buildEnvStats, err := detectBuildEnvs(logger, source, git.NewSecretProvider(sshKey), allEnvServiceCreators(true))
 
 	// then
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "cannot decode encrypted private keys")
-	require.Nil(t, buildEnvStats)
+	require.NoError(t, err)
+	assert.Empty(t, buildEnvStats.DetectedBuildTypes)
+	assert.Empty(t, buildEnvStats.SortedLanguages)
 }
 
 func TestFailingGetFileList(t *testing.T) {
@@ -158,10 +148,8 @@ func TestGenericGitUsingSshAccessingGitLabWithDefaultCredentials(t *testing.T) {
 
 	// then
 	require.NoError(t, err)
-	require.Len(t, buildEnvStats.DetectedBuildTypes, 1)
-	assertContainsBuildTool(t, buildEnvStats.DetectedBuildTypes, build.Maven, "pom.xml")
-	require.Len(t, buildEnvStats.SortedLanguages, 6)
-	assert.Contains(t, buildEnvStats.SortedLanguages, "Java")
+	assert.Empty(t, buildEnvStats.DetectedBuildTypes)
+	assert.Empty(t, buildEnvStats.SortedLanguages)
 }
 
 func TestGenericGitUsingSshAccessingBitbucketWithDefaultCredentials(t *testing.T) {
@@ -173,10 +161,8 @@ func TestGenericGitUsingSshAccessingBitbucketWithDefaultCredentials(t *testing.T
 
 	// then
 	require.NoError(t, err)
-	require.Len(t, buildEnvStats.DetectedBuildTypes, 1)
-	assertContainsBuildTool(t, buildEnvStats.DetectedBuildTypes, build.Maven, "pom.xml")
-	require.Len(t, buildEnvStats.SortedLanguages, 6)
-	assert.Contains(t, buildEnvStats.SortedLanguages, "Java")
+	assert.Empty(t, buildEnvStats.DetectedBuildTypes)
+	assert.Empty(t, buildEnvStats.SortedLanguages)
 }
 
 func TestGenericGitUsingSshAccessingGitHubWithDefaultCredentials(t *testing.T) {
@@ -188,10 +174,8 @@ func TestGenericGitUsingSshAccessingGitHubWithDefaultCredentials(t *testing.T) {
 
 	// then
 	require.NoError(t, err)
-	require.Len(t, buildEnvStats.DetectedBuildTypes, 1)
-	assertContainsBuildTool(t, buildEnvStats.DetectedBuildTypes, build.Maven, "pom.xml")
-	require.Len(t, buildEnvStats.SortedLanguages, 6)
-	assert.Contains(t, buildEnvStats.SortedLanguages, "Java")
+	assert.Empty(t, buildEnvStats.DetectedBuildTypes)
+	assert.Empty(t, buildEnvStats.SortedLanguages)
 }
 
 // ignored tests as they reach the real services or needs specific credentials


### PR DESCRIPTION
This PR removes generic git from the list of build type detectors. The reason is that we don't want to download anything big there until we solve the resources issue. So for the unknown repositories or for the cases when ssh key is used, the detector will respond just empty statistics.