### PR TITLE
feat(ODC-64): add credentials,repository and branch validation

### DIFF
--- a/pkg/git/connection/validator.go
+++ b/pkg/git/connection/validator.go
@@ -17,14 +17,14 @@ import (
 	"strings"
 )
 
-// ValidateGitSource validates if a git repository defined by the given GitSource is reachable
-// and if it contains the defined branch (master if empty)
 var gitServiceCreators = []repository.ServiceCreator{
 	github.NewRepoServiceIfMatches(),
 	bitbucket.NewRepoServiceIfMatches(),
 	gitlab.NewRepoServiceIfMatches(),
 }
 
+// ValidateGitSource validates if a git repository defined by the given GitSource is reachable
+// and if it contains the defined branch (master if empty)
 func ValidateGitSource(log *log.GitSourceLogger, gitSource *v1alpha1.GitSource) *ValidationError {
 	endpoint, err := gittransport.NewEndpoint(gitSource.Spec.URL)
 	if err != nil {

--- a/pkg/git/connection/validator.go
+++ b/pkg/git/connection/validator.go
@@ -3,7 +3,12 @@ package connection
 import (
 	"fmt"
 	"github.com/redhat-developer/devconsole-api/pkg/apis/devconsole/v1alpha1"
+	"github.com/redhat-developer/devconsole-git/pkg/git"
 	"github.com/redhat-developer/devconsole-git/pkg/git/repository"
+	"github.com/redhat-developer/devconsole-git/pkg/git/repository/bitbucket"
+	"github.com/redhat-developer/devconsole-git/pkg/git/repository/generic"
+	"github.com/redhat-developer/devconsole-git/pkg/git/repository/github"
+	"github.com/redhat-developer/devconsole-git/pkg/git/repository/gitlab"
 	"github.com/redhat-developer/devconsole-git/pkg/log"
 	gittransport "gopkg.in/src-d/go-git.v4/plumbing/transport"
 	"io/ioutil"
@@ -14,6 +19,12 @@ import (
 
 // ValidateGitSource validates if a git repository defined by the given GitSource is reachable
 // and if it contains the defined branch (master if empty)
+var gitServiceCreators = []repository.ServiceCreator{
+	github.NewRepoServiceIfMatches(),
+	bitbucket.NewRepoServiceIfMatches(),
+	gitlab.NewRepoServiceIfMatches(),
+}
+
 func ValidateGitSource(log *log.GitSourceLogger, gitSource *v1alpha1.GitSource) *ValidationError {
 	endpoint, err := gittransport.NewEndpoint(gitSource.Spec.URL)
 	if err != nil {
@@ -66,4 +77,37 @@ func validateBranch(log *log.GitSourceLogger, branch string, resp *http.Response
 		return nil
 	}
 	return newValidationErrorf(v1alpha1.BranchNotFound, "cannot find the branch")
+}
+
+// ValidateGitSourceWithSecret detects build tools and languages using the given secret in the git repository
+// defined by the given v1alpha1.GitSource
+func ValidateGitSourceWithSecret(log *log.GitSourceLogger, gitSource *v1alpha1.GitSource, secret git.Secret) *ValidationError {
+	return validateGitSourceWithSecret(log, gitSource, git.NewSecretProvider(secret), gitServiceCreators)
+}
+
+func validateGitSourceWithSecret(log *log.GitSourceLogger,
+	gitSource *v1alpha1.GitSource,
+	secretProvider *git.SecretProvider,
+	serviceCreators []repository.ServiceCreator) *ValidationError {
+
+	service, err := repository.NewGitService(log, gitSource, secretProvider, serviceCreators)
+	if err != nil {
+		return newValidationErrorf(v1alpha1.RepoNotReachable, err.Error())
+	}
+	if service == nil {
+		service, err = generic.NewRepositoryService(gitSource, secretProvider)
+		if err != nil {
+			return newValidationErrorf(v1alpha1.RepoNotReachable, err.Error())
+		}
+	}
+	if err := service.CheckCredentials(); err != nil {
+		return newValidationErrorf(v1alpha1.BadCredentials, "cannot get user information: %s", err.Error())
+	}
+	if err := service.CheckRepoAccessibility(); err != nil {
+		return newValidationErrorf(v1alpha1.RepoNotReachable, "unable to reach the URL: %s", err.Error())
+	}
+	if err := service.CheckBranch(); err != nil {
+		return newValidationErrorf(v1alpha1.BranchNotFound, "unable to find the branch: %s", err.Error())
+	}
+	return nil
 }

--- a/pkg/git/connection/validator_test.go
+++ b/pkg/git/connection/validator_test.go
@@ -2,17 +2,26 @@ package connection_test
 
 import (
 	"github.com/redhat-developer/devconsole-api/pkg/apis/devconsole/v1alpha1"
+	"github.com/redhat-developer/devconsole-git/pkg/git"
 	"github.com/redhat-developer/devconsole-git/pkg/git/connection"
 	"github.com/redhat-developer/devconsole-git/pkg/log"
 	"github.com/redhat-developer/devconsole-git/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
+	"os"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"testing"
 )
 
-var logger = &log.GitSourceLogger{Logger: logf.Log}
+var (
+	logger  = &log.GitSourceLogger{Logger: logf.Log}
+	homeDir = os.Getenv("HOME")
+)
+
+//
+// Tests without secret
+//
 
 func TestIsReachableRealGHRepoWithDevelopBranch(t *testing.T) {
 	// given
@@ -115,5 +124,74 @@ func TestIsReachableForWrongURL(t *testing.T) {
 
 	// then
 	require.NotNil(t, validationErr)
+	assert.Equal(t, v1alpha1.RepoNotReachable, validationErr.Reason)
+}
+
+//
+// Tests with secret
+//
+
+func TestValidateRealGitHubInvalidSecret(t *testing.T) {
+	// given
+	glSource := test.NewGitSource(
+		test.WithURL("https://github.com/MatousJobanek/quarkus-knative"))
+
+	// when
+	validationErr := connection.ValidateGitSourceWithSecret(logger, glSource, git.NewOauthToken([]byte("some-token")))
+
+	// then
+	require.NotNil(t, validationErr)
+	assert.Equal(t, v1alpha1.BadCredentials, validationErr.Reason)
+}
+
+func TestValidateGitLabSecretAndAvailableRepo(t *testing.T) {
+	// given
+	defer gock.OffAll()
+	glSource := test.NewGitSource(test.WithURL("https://gitlab.com/matousjobanek/quarkus-knative"))
+	gock.New("https://gitlab.com/").
+		Get("/api/v4/user").
+		SetMatcher(test.TurnOffAllGockWhenMatched()).
+		Reply(200).
+		BodyString("{}")
+
+	// when
+	err := connection.ValidateGitSourceWithSecret(logger, glSource, git.NewOauthToken([]byte("")))
+
+	// then
+	require.Nil(t, err)
+}
+
+func TestValidateGitLabSecretAndAvailableRepoWithWrongBranch(t *testing.T) {
+	// given
+	defer gock.OffAll()
+	glSource := test.NewGitSource(
+		test.WithURL("https://gitlab.com/matousjobanek/quarkus-knative"),
+		test.WithRef("any"))
+	gock.New("https://gitlab.com/").
+		Get("/api/v4/user").
+		SetMatcher(test.TurnOffAllGockWhenMatched()).
+		Reply(200).
+		BodyString("{}")
+
+	// when
+	validationErr := connection.ValidateGitSourceWithSecret(logger, glSource, git.NewOauthToken([]byte("")))
+
+	// then
+	assert.Equal(t, v1alpha1.BranchNotFound, validationErr.Reason)
+}
+
+func TestValidateBitBucketWrongRepo(t *testing.T) {
+	// given
+	defer gock.OffAll()
+	glSource := test.NewGitSource(test.WithURL("https://bitbucket.org/some-org/some-repo"))
+	gock.New("https://api.bitbucket.org/").
+		Get("/2.0/user").
+		SetMatcher(test.TurnOffAllGockWhenMatched()).
+		Reply(200)
+
+	// when
+	validationErr := connection.ValidateGitSourceWithSecret(logger, glSource, git.NewOauthToken([]byte("")))
+
+	// then
 	assert.Equal(t, v1alpha1.RepoNotReachable, validationErr.Reason)
 }

--- a/pkg/git/connection/validator_whitebox_test.go
+++ b/pkg/git/connection/validator_whitebox_test.go
@@ -1,0 +1,46 @@
+package connection
+
+import (
+	"github.com/redhat-developer/devconsole-git/pkg/git"
+	"github.com/redhat-developer/devconsole-git/pkg/git/repository"
+	"github.com/redhat-developer/devconsole-git/pkg/git/repository/bitbucket"
+	"github.com/redhat-developer/devconsole-git/pkg/git/repository/github"
+	"github.com/redhat-developer/devconsole-git/pkg/git/repository/gitlab"
+	"github.com/redhat-developer/devconsole-git/pkg/log"
+	"github.com/redhat-developer/devconsole-git/pkg/test"
+	"github.com/stretchr/testify/require"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"testing"
+)
+
+var logger = &log.GitSourceLogger{Logger: logf.Log}
+
+func TestGenericGitUsingSshAccessingGitHub(t *testing.T) {
+	// given
+	ghSource := test.NewGitSource(test.WithURL("https://github.com/MatousJobanek/quarkus-knative.git"))
+	allButGh := []repository.ServiceCreator{
+		bitbucket.NewRepoServiceIfMatches(),
+		gitlab.NewRepoServiceIfMatches(),
+	}
+
+	// when
+	validationError := validateGitSourceWithSecret(logger, ghSource, git.NewSecretProvider(nil), allButGh)
+
+	// then
+	require.Nil(t, validationError)
+}
+
+func TestGenericGitUsingSshAccessingGitLab(t *testing.T) {
+	// given
+	ghSource := test.NewGitSource(test.WithURL("https://gitlab.com/matousjobanek/quarkus-knative.git"))
+	allButGl := []repository.ServiceCreator{
+		github.NewRepoServiceIfMatches(),
+		bitbucket.NewRepoServiceIfMatches(),
+	}
+
+	// when
+	validationError := validateGitSourceWithSecret(logger, ghSource, git.NewSecretProvider(nil), allButGl)
+
+	// then
+	require.Nil(t, validationError)
+}

--- a/pkg/git/repository/github/service.go
+++ b/pkg/git/repository/github/service.go
@@ -110,3 +110,25 @@ func isAnonymousSecret(secret git.Secret) bool {
 	return secret.SecretType() == git.UsernamePasswordType &&
 		secret.SecretContent() == anonymousSecret.SecretContent()
 }
+
+func (s *RepositoryService) CheckCredentials() error {
+	_, _, err := s.client.Users.Get(context.Background(), "")
+	return err
+}
+
+func (s *RepositoryService) CheckRepoAccessibility() error {
+	_, _, err := s.client.Repositories.Get(
+		context.Background(),
+		s.repo.Owner,
+		s.repo.Name)
+	return err
+}
+
+func (s *RepositoryService) CheckBranch() error {
+	_, _, err := s.client.Repositories.GetBranch(
+		context.Background(),
+		s.repo.Owner,
+		s.repo.Name,
+		s.repo.Branch)
+	return err
+}

--- a/pkg/git/repository/service.go
+++ b/pkg/git/repository/service.go
@@ -12,6 +12,12 @@ type GitService interface {
 	FileExistenceChecker() (FileExistenceChecker, error)
 	// GetLanguageList returns list of detected languages in the sorted order where the first one is the most used
 	GetLanguageList() ([]string, error)
+	// CheckCredentials tries to get user  information associated with the attached secret from the git server
+	CheckCredentials() error
+	// Tries to connect to the git repository with the attached secret
+	CheckRepoAccessibility() error
+	// Checks if the branch exists in the git repository
+	CheckBranch() error
 }
 
 type FileExistenceChecker interface {

--- a/pkg/git/secret.go
+++ b/pkg/git/secret.go
@@ -186,9 +186,20 @@ func ParseUsernameAndPassword(secret string) (string, string) {
 	return "", ""
 }
 
+// NewGitSecretProvider retrieves secret using the given client
+// and stores it to a new instance of GitSecretProvider that is then returned
 func NewGitSecretProvider(client client.Client, namespace string, gitSource *v1alpha1.GitSource) (*SecretProvider, error) {
+	secret, err := NewGitSecret(client, namespace, gitSource)
+	if err != nil {
+		return nil, err
+	}
+	return NewSecretProvider(secret), nil
+}
+
+// NewGitSecret retrieves a secret using the given client
+func NewGitSecret(client client.Client, namespace string, gitSource *v1alpha1.GitSource) (Secret, error) {
 	if gitSource.Spec.SecretRef == nil {
-		return NewSecretProvider(nil), nil
+		return nil, nil
 	}
 	coreSecret := &corev1.Secret{}
 	namespacedSecretName := types.NamespacedName{Namespace: namespace, Name: gitSource.Spec.SecretRef.Name}
@@ -211,5 +222,5 @@ func NewGitSecretProvider(client client.Client, namespace string, gitSource *v1a
 		return nil, fmt.Errorf("the provided secret does not contain any of the required parameters: [%s,%s,%s] or they are empty",
 			corev1.BasicAuthUsernameKey, corev1.BasicAuthPasswordKey, corev1.SSHAuthPrivateKey)
 	}
-	return NewSecretProvider(secret), nil
+	return secret, nil
 }

--- a/pkg/test/git.go
+++ b/pkg/test/git.go
@@ -29,10 +29,11 @@ func NewDummyGitRepo(t *testing.T, branchName string) *DummyGitRepo {
 	require.NoError(t, err)
 	client, err := gogit.PlainInit(clientPath, false)
 	require.NoError(t, err)
-	client.CreateRemote(&config.RemoteConfig{
+	_, err = client.CreateRemote(&config.RemoteConfig{
 		URLs: []string{path},
 		Name: gogit.DefaultRemoteName,
 	})
+	require.NoError(t, err)
 
 	worktree, err := client.Worktree()
 	require.NoError(t, err)
@@ -46,10 +47,7 @@ func NewDummyGitRepo(t *testing.T, branchName string) *DummyGitRepo {
 	dummyGitRepo.createInitialCommits()
 
 	if branchName != repository.Master {
-		err = worktree.Checkout(&gogit.CheckoutOptions{
-			Branch: plumbing.ReferenceName("refs/heads/" + branchName),
-			Create: true,
-		})
+		dummyGitRepo.CheckoutBranch(branchName)
 		require.NoError(t, err)
 	}
 
@@ -92,4 +90,12 @@ func newCommitOptions() *gogit.CommitOptions {
 			When:  time.Now(),
 		},
 	}
+}
+
+func (r *DummyGitRepo) CheckoutBranch(branchName string) {
+	err := r.workTree.Checkout(&gogit.CheckoutOptions{
+		Branch: plumbing.ReferenceName("refs/heads/" + branchName),
+		Create: true,
+	})
+	require.NoError(r.t, err)
 }

--- a/pkg/test/gock.go
+++ b/pkg/test/gock.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
 	"math/rand"
+	"net/http"
 	"strings"
 	"testing"
 )
@@ -87,4 +88,14 @@ func String(value string) *string {
 }
 func Boolean(value bool) *bool {
 	return &value
+}
+
+// TurnOffAllGockWhenMatched turns off all gock mocks when the matcher is matched
+func TurnOffAllGockWhenMatched() gock.Matcher {
+	matcher := gock.NewBasicMatcher()
+	matcher.Add(func(req *http.Request, _ *gock.Request) (bool, error) {
+		gock.OffAll()
+		return true, nil
+	})
+	return matcher
 }

--- a/pkg/test/service.go
+++ b/pkg/test/service.go
@@ -77,3 +77,13 @@ func (s *DummyService) Creator() repository.ServiceCreator {
 		return nil, nil
 	}
 }
+
+func (s *DummyService) CheckCredentials() error {
+	return nil
+}
+func (s *DummyService) CheckRepoAccessibility() error {
+	return nil
+}
+func (s *DummyService) CheckBranch() error {
+	return nil
+}


### PR DESCRIPTION
Introduces new connection validations when a secret is provided. Those validations are:
* if credentials are valid - user can log in
* if the repository is reachable with the secret
* if the repository contains given branch (`master` if empty)

Every git sevice implementation uses their own API calls. In case none of the well-known services is matched, then it uses the generic git. Generic git gets only the list of remote branches (same as `git ls-remote`)