### PR TITLE
feat: add failure reason to status when analysis fails

### DIFF
--- a/pkg/git/detector/detector.go
+++ b/pkg/git/detector/detector.go
@@ -41,7 +41,7 @@ func detectBuildEnvs(log *log.GitSourceLogger,
 		return nil, err
 	}
 	if service == nil {
-		return &v1alpha1.BuildEnvStats{}, nil
+		return nil, nil
 	}
 	return detectBuildEnvsUsingService(service)
 }

--- a/pkg/git/detector/detector_whitebox_test.go
+++ b/pkg/git/detector/detector_whitebox_test.go
@@ -42,10 +42,7 @@ func TestDetectBuildEnvsShouldUseGenericGitIfNotOtherMatches(t *testing.T) {
 
 	// then
 	require.NoError(t, err)
-	require.NotNil(t, buildEnvStats)
-
-	assert.Empty(t, buildEnvStats.DetectedBuildTypes)
-	assert.Empty(t, buildEnvStats.SortedLanguages)
+	assert.Nil(t, buildEnvStats)
 }
 
 func TestFailingCreator(t *testing.T) {
@@ -72,8 +69,7 @@ func TestFailingGenericGitCreation(t *testing.T) {
 
 	// then
 	require.NoError(t, err)
-	assert.Empty(t, buildEnvStats.DetectedBuildTypes)
-	assert.Empty(t, buildEnvStats.SortedLanguages)
+	assert.Nil(t, buildEnvStats)
 }
 
 func TestFailingGetFileList(t *testing.T) {
@@ -148,8 +144,7 @@ func TestGenericGitUsingSshAccessingGitLabWithDefaultCredentials(t *testing.T) {
 
 	// then
 	require.NoError(t, err)
-	assert.Empty(t, buildEnvStats.DetectedBuildTypes)
-	assert.Empty(t, buildEnvStats.SortedLanguages)
+	assert.Nil(t, buildEnvStats)
 }
 
 func TestGenericGitUsingSshAccessingBitbucketWithDefaultCredentials(t *testing.T) {
@@ -161,8 +156,7 @@ func TestGenericGitUsingSshAccessingBitbucketWithDefaultCredentials(t *testing.T
 
 	// then
 	require.NoError(t, err)
-	assert.Empty(t, buildEnvStats.DetectedBuildTypes)
-	assert.Empty(t, buildEnvStats.SortedLanguages)
+	assert.Nil(t, buildEnvStats)
 }
 
 func TestGenericGitUsingSshAccessingGitHubWithDefaultCredentials(t *testing.T) {
@@ -174,8 +168,7 @@ func TestGenericGitUsingSshAccessingGitHubWithDefaultCredentials(t *testing.T) {
 
 	// then
 	require.NoError(t, err)
-	assert.Empty(t, buildEnvStats.DetectedBuildTypes)
-	assert.Empty(t, buildEnvStats.SortedLanguages)
+	assert.Nil(t, buildEnvStats)
 }
 
 // ignored tests as they reach the real services or needs specific credentials


### PR DESCRIPTION
When something fails during the `GitSource` analysis, then the controller adds corresponding reason to the status of the `GitSourceAnalysis` CR