### PR TITLE
fix: validate correctly URL ending with slash

### DIFF
--- a/pkg/git/connection/validator.go
+++ b/pkg/git/connection/validator.go
@@ -35,6 +35,9 @@ func ValidateGitSource(log *log.GitSourceLogger, gitSource *v1alpha1.GitSource) 
 	}
 	client := &http.Client{}
 	path := endpoint.Path
+	if strings.HasSuffix(path, "/") {
+		path = path[:len(path)-1]
+	}
 	if !strings.HasSuffix(path, ".git") {
 		path += ".git"
 	}

--- a/pkg/git/connection/validator_test.go
+++ b/pkg/git/connection/validator_test.go
@@ -36,6 +36,18 @@ func TestIsReachableRealGHRepoWithDevelopBranch(t *testing.T) {
 	assert.Nil(t, validationErr)
 }
 
+func TestIsReachableRealGHRepoUrlEndingWithSlash(t *testing.T) {
+	// given
+	gitSource := test.NewGitSource(
+		test.WithURL("https://github.com/fabric8-services/fabric8-tenant/"))
+
+	// when
+	validationErr := connection.ValidateGitSource(logger, gitSource)
+
+	// then
+	assert.Nil(t, validationErr)
+}
+
 func TestIsReachableRealGLRepoWithNoBranchSet(t *testing.T) {
 	// given
 	gitSource := test.NewGitSource(test.WithURL("https://gitlab.com/matousjobanek/quarkus-knative"))


### PR DESCRIPTION
there was incorrectly created a URL (used for reachability checking of repo when secret is not provided) when the provided repo URL was ending with a slash